### PR TITLE
[TECH](RC) allow multiple FDS parsing

### DIFF
--- a/src/topics/engine/pdf-extractor/__tests__/pdf-image-text-extractor.service.test.ts
+++ b/src/topics/engine/pdf-extractor/__tests__/pdf-image-text-extractor.service.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, it } from 'vitest';
+import fsPromises from 'fs/promises';
+
+import { describe, expect, it, vi } from 'vitest';
 
 import { PdfImageTextExtractorService } from '@topics/engine/pdf-extractor/pdf-image-text-extractor.service.js';
 import { FDS_TEST_FILES_PATH } from '@src/__fixtures__/fixtures.constants.js';
@@ -6,9 +8,14 @@ import { FDS_TEST_FILES_PATH } from '@src/__fixtures__/fixtures.constants.js';
 describe('PdfImageTextExtractorService tests', () => {
   describe('getTextFromImagePdf tests', () => {
     it('should return text from image pdf', async () => {
+      const mkdirSpy = vi.spyOn(fsPromises, 'mkdir');
+      const rmSpy = vi.spyOn(fsPromises, 'rm');
+
       await expect(
         PdfImageTextExtractorService.getTextFromImagePdf(FDS_TEST_FILES_PATH.IMAGE_DEGRAISSANT, { numberOfPagesToParse: 1 }),
       ).resolves.toMatchSnapshot();
+      expect(mkdirSpy).toHaveBeenCalledOnce();
+      expect(rmSpy).toHaveBeenCalledOnce();
     });
 
     it('should return an empty list when numberOfPagesToParse is not specified', async () => {

--- a/src/topics/engine/pdf-extractor/pdf-image-text-extractor.service.ts
+++ b/src/topics/engine/pdf-extractor/pdf-image-text-extractor.service.ts
@@ -1,49 +1,54 @@
+import fsPromises from 'fs/promises';
+
 import { decode } from 'html-entities';
 import { createWorker } from 'tesseract.js';
-import { fromPath } from 'pdf2pic';
 import { promiseMapSeries } from '@padoa/promise';
 import _ from 'lodash';
 import type { Options } from 'pdf2pic/dist/types/options.js';
+import { fromPath } from 'pdf2pic';
 
 import type { IBox, ILine, IPageDimension, IText } from '@topics/engine/model/fds.model.js';
 
 export class PdfImageTextExtractorService {
-  private static readonly tempImageFileName = 'fds-image';
-  private static readonly tempImageFolderName = '/tmp';
-  private static readonly tempImageFormat = 'png';
-
-  private static readonly options: Options = {
-    density: 300,
-    saveFilename: this.tempImageFileName,
-    savePath: `${this.tempImageFolderName}`,
-    format: this.tempImageFormat,
-    width: 1050,
-    height: 1485,
-  };
-
   public static async getTextFromImagePdf(fdsFilePath: string, { numberOfPagesToParse }: { numberOfPagesToParse?: number } = {}): Promise<ILine[]> {
-    await this.pdfToImage(fdsFilePath, { numberOfPagesToParse });
+    const options = await this.pdfToImage(fdsFilePath, { numberOfPagesToParse });
 
     const worker = await createWorker('fra');
     const texts = await promiseMapSeries(_.range(0, numberOfPagesToParse), async (index) => {
-      return this.getTextFromImage(worker, index + 1);
+      return this.getTextFromImage(worker, index + 1, options);
     });
     await worker.terminate();
+    await fsPromises.rm(options.savePath, { recursive: true });
 
     return _.flatMap(texts);
   }
 
-  private static pdfToImage = async (pathToFile: string, { numberOfPagesToParse }: { numberOfPagesToParse: number }): Promise<void> => {
-    // TODO: clean temporary images folder
-    await fromPath(pathToFile, this.options)
-      .bulk(_.range(1, numberOfPagesToParse + 2), { responseType: 'image' })
-      .then((resolve) => {
-        return resolve;
-      });
+  private static pdfToImage = async (pathToFile: string, { numberOfPagesToParse }: { numberOfPagesToParse: number }): Promise<Options> => {
+    const options = await this.getPdf2PicOptions();
+    await fromPath(pathToFile, options).bulk(_.range(1, numberOfPagesToParse + 2), { responseType: 'image' });
+    return options;
   };
 
-  private static getTextFromImage = async (worker: Tesseract.Worker, pageNumber: number): Promise<ILine[]> => {
-    const imagePath = `${this.tempImageFolderName}/${this.tempImageFileName}.${pageNumber}.${this.tempImageFormat}`;
+  private static async getPdf2PicOptions(): Promise<Options> {
+    const savePath = `/tmp/fds/${new Date().getTime().toString()}`;
+    await fsPromises.mkdir(savePath, { recursive: true });
+
+    return {
+      density: 300,
+      savePath,
+      saveFilename: 'fds-image',
+      format: 'png',
+      width: 1050,
+      height: 1485,
+    };
+  }
+
+  private static getTextFromImage = async (
+    worker: Tesseract.Worker,
+    pageNumber: number,
+    { savePath, saveFilename, format }: Options,
+  ): Promise<ILine[]> => {
+    const imagePath = `${savePath}/${saveFilename}.${pageNumber}.${format}`;
     const ret = await worker.recognize(imagePath);
     return this.hocrToLines(ret.data.hocr, pageNumber);
   };

--- a/src/topics/engine/pdf-extractor/pdf-image-text-extractor.service.ts
+++ b/src/topics/engine/pdf-extractor/pdf-image-text-extractor.service.ts
@@ -7,20 +7,20 @@ import type { Options } from 'pdf2pic/dist/types/options.js';
 
 import type { IBox, ILine, IPageDimension, IText } from '@topics/engine/model/fds.model.js';
 
-const tempImageFileName = 'fds-image';
-const tempImageFolderName = '/tmp';
-const tempImageFormat = 'png';
-
-const options: Options = {
-  density: 300,
-  saveFilename: tempImageFileName,
-  savePath: `${tempImageFolderName}`,
-  format: tempImageFormat,
-  width: 1050,
-  height: 1485,
-};
-
 export class PdfImageTextExtractorService {
+  private static readonly tempImageFileName = 'fds-image';
+  private static readonly tempImageFolderName = '/tmp';
+  private static readonly tempImageFormat = 'png';
+
+  private static readonly options: Options = {
+    density: 300,
+    saveFilename: this.tempImageFileName,
+    savePath: `${this.tempImageFolderName}`,
+    format: this.tempImageFormat,
+    width: 1050,
+    height: 1485,
+  };
+
   public static async getTextFromImagePdf(fdsFilePath: string, { numberOfPagesToParse }: { numberOfPagesToParse?: number } = {}): Promise<ILine[]> {
     await this.pdfToImage(fdsFilePath, { numberOfPagesToParse });
 
@@ -35,7 +35,7 @@ export class PdfImageTextExtractorService {
 
   private static pdfToImage = async (pathToFile: string, { numberOfPagesToParse }: { numberOfPagesToParse: number }): Promise<void> => {
     // TODO: clean temporary images folder
-    await fromPath(pathToFile, options)
+    await fromPath(pathToFile, this.options)
       .bulk(_.range(1, numberOfPagesToParse + 2), { responseType: 'image' })
       .then((resolve) => {
         return resolve;
@@ -43,7 +43,7 @@ export class PdfImageTextExtractorService {
   };
 
   private static getTextFromImage = async (worker: Tesseract.Worker, pageNumber: number): Promise<ILine[]> => {
-    const imagePath = `${tempImageFolderName}/${tempImageFileName}.${pageNumber}.${tempImageFormat}`;
+    const imagePath = `${this.tempImageFolderName}/${this.tempImageFileName}.${pageNumber}.${this.tempImageFormat}`;
     const ret = await worker.recognize(imagePath);
     return this.hocrToLines(ret.data.hocr, pageNumber);
   };


### PR DESCRIPTION
### Description

* Supprimer les images des FDS une fois qu'elles ont été parsées
* Rendre possible le parsing de plusieurs FDS en parallèles en ajoutant un dossier dans tmp avec le timeStamp pour que ça n'override pas les images si on en lance deux en même temps

### Carte Notion
[[Moteur de FDS][POC FDS image] Rendre maintenable le code du poc d’extraction de texte à partir d’un](https://www.notion.so/padoa/Moteur-de-FDS-POC-FDS-image-Rendre-maintenable-le-code-du-poc-d-extraction-de-texte-partir-d-une-d0d3e71fd4fb47e390fee48f983afa63)
