### PR TITLE
[Feat](RC) Ajoute la règle pour les phrases H pour les substances

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   "dependencies": {
     "@padoa/async-local-storage": "^2.0.2",
     "@padoa/axios": "^5.0.4",
-    "@padoa/chemical-risk": "1.0.0-6b64ca7e6fa4286f8c1ae612208bb2a46f4a8912",
+    "@padoa/chemical-risk": "1.1.0-9b2eb2300541c2c8688ebad211586548b138d9bf",
     "@padoa/csv-tools": "^2.0.4",
     "@padoa/database": "^26.2.0",
     "@padoa/express": "^15.0.2",

--- a/src/tasks/extract/from-all-fds.ts
+++ b/src/tasks/extract/from-all-fds.ts
@@ -99,6 +99,7 @@ const saveInCsv = async (
         casNumber: substance.casNumber?.value,
         ceNumber: substance.ceNumber?.value,
         concentration: substance.concentration?.value,
+        hazards: _.map(substance.hazards, 'code'),
       })),
     ),
     physicalState?.value,

--- a/src/tasks/extract/from-fds.ts
+++ b/src/tasks/extract/from-fds.ts
@@ -21,21 +21,28 @@ const main = async (): Promise<void> => {
 
   logger.info(`🔵  Extracting data from ${filename}...`);
   const data = await FdsEngineService.extractDataFromFds(filename);
-  logger.info(`✅  Data extracted:`, {
-    date: data.dataExtracted?.date,
-    product: data.dataExtracted?.product?.name,
-    producer: data.dataExtracted?.producer?.name,
-    dangers: _.map(data.dataExtracted?.dangers, 'code'),
-    substances: _.map(data.dataExtracted?.substances, (substance) => ({
-      casNumber: substance.casNumber?.value,
-      ceNumber: substance.ceNumber?.value,
-      concentration: substance.concentration?.value,
-    })),
-    physicalState: data.dataExtracted?.physicalState?.value,
-    vaporPressure: _.pick(data.dataExtracted?.vaporPressure, ['pressure', 'temperature']),
-    boilingPoint: data.dataExtracted?.boilingPoint?.value,
-    fromImage: data.fromImage,
-  });
+  logger.info(
+    `✅  Data extracted:`,
+
+    {
+      date: data.dataExtracted?.date,
+      product: data.dataExtracted?.product?.name,
+      producer: data.dataExtracted?.producer?.name,
+      dangers: _.map(data.dataExtracted?.dangers, 'code'),
+      substances: _.map(data.dataExtracted?.substances, (substance) => ({
+        casNumber: substance.casNumber?.value,
+        ceNumber: substance.ceNumber?.value,
+        concentration: substance.concentration?.value,
+        hazards: JSON.stringify(_.map(substance.hazards, 'code')),
+      })),
+      physicalState: data.dataExtracted?.physicalState?.value,
+      vaporPressure: _.pick(data.dataExtracted?.vaporPressure, ['pressure', 'temperature']),
+      boilingPoint: data.dataExtracted?.boilingPoint?.value,
+      fromImage: data.fromImage,
+    },
+    null,
+    1,
+  );
 };
 
 main()

--- a/src/tasks/extract/from-fds.ts
+++ b/src/tasks/extract/from-fds.ts
@@ -21,28 +21,22 @@ const main = async (): Promise<void> => {
 
   logger.info(`🔵  Extracting data from ${filename}...`);
   const data = await FdsEngineService.extractDataFromFds(filename);
-  logger.info(
-    `✅  Data extracted:`,
-
-    {
-      date: data.dataExtracted?.date,
-      product: data.dataExtracted?.product?.name,
-      producer: data.dataExtracted?.producer?.name,
-      dangers: _.map(data.dataExtracted?.dangers, 'code'),
-      substances: _.map(data.dataExtracted?.substances, (substance) => ({
-        casNumber: substance.casNumber?.value,
-        ceNumber: substance.ceNumber?.value,
-        concentration: substance.concentration?.value,
-        hazards: JSON.stringify(_.map(substance.hazards, 'code')),
-      })),
-      physicalState: data.dataExtracted?.physicalState?.value,
-      vaporPressure: _.pick(data.dataExtracted?.vaporPressure, ['pressure', 'temperature']),
-      boilingPoint: data.dataExtracted?.boilingPoint?.value,
-      fromImage: data.fromImage,
-    },
-    null,
-    1,
-  );
+  logger.info(`✅  Data extracted:`, {
+    date: data.dataExtracted?.date,
+    product: data.dataExtracted?.product?.name,
+    producer: data.dataExtracted?.producer?.name,
+    dangers: _.map(data.dataExtracted?.dangers, 'code'),
+    substances: _.map(data.dataExtracted?.substances, (substance) => ({
+      casNumber: substance.casNumber?.value,
+      ceNumber: substance.ceNumber?.value,
+      concentration: substance.concentration?.value,
+      hazards: JSON.stringify(_.map(substance.hazards, 'code')),
+    })),
+    physicalState: data.dataExtracted?.physicalState?.value,
+    vaporPressure: _.pick(data.dataExtracted?.vaporPressure, ['pressure', 'temperature']),
+    boilingPoint: data.dataExtracted?.boilingPoint?.value,
+    fromImage: data.fromImage,
+  });
 };
 
 main()

--- a/src/topics/engine/__fixtures__/fds-tree.mother.ts
+++ b/src/topics/engine/__fixtures__/fds-tree.mother.ts
@@ -1,6 +1,5 @@
 import { FdsTreeBuilder } from '@topics/engine/__fixtures__/fds-tree.builder.js';
 import {
-  aLineWithCasAndCeNumberAndConcentrationIn3Texts,
   aLineWithProducerIdentifierOnlyWithColon,
   aLineWithProducerNameOnly,
   aLineWithProductIn1Text,
@@ -8,9 +7,11 @@ import {
   aLineWithThreeDangersAndTheirDetails,
   aLineWithPhysicalStateIdentifierAndValue,
   aLineWithBoilingPointIdentifierAndValue,
+  aLine,
 } from '@topics/engine/__fixtures__/line.mother.js';
 import { aSection } from '@topics/engine/__fixtures__/section.mother.js';
 import { aSubSection, aSubSectionWithContent } from '@topics/engine/__fixtures__/sub-section.mother.js';
+import { aTextWithCasNumber, aTextWithCeNumber, aTextWithConcentration, aTextWithHDanger } from '@topics/engine/__fixtures__/text.mother.js';
 
 export const aFdsTree = (): FdsTreeBuilder => new FdsTreeBuilder();
 
@@ -41,7 +42,14 @@ export const aFdsTreeWithAllSectionsWithUsefulInfo = (): FdsTreeBuilder =>
     )
     .withSection3(
       aSection().withSubsections({
-        2: aSubSection().withLines([aLineWithCasAndCeNumberAndConcentrationIn3Texts().properties]).properties,
+        2: aSubSection().withLines([
+          aLine().withTexts([
+            aTextWithCasNumber().properties,
+            aTextWithCeNumber().properties,
+            aTextWithConcentration().properties,
+            aTextWithHDanger().properties,
+          ]).properties,
+        ]).properties,
       }).properties,
     )
     .withSection9(

--- a/src/topics/engine/__fixtures__/line.mother.ts
+++ b/src/topics/engine/__fixtures__/line.mother.ts
@@ -32,7 +32,6 @@ import {
   aTextWithVaporPressureValue,
   aTextWithBoilingPointIdentifier,
   aTextWithBoilingPointValue,
-  aTextWithConcentration,
 } from '@topics/engine/__fixtures__/text.mother.js';
 
 export const aLine = (): LineBuilder => new LineBuilder();
@@ -116,8 +115,6 @@ export const aLineWithCasNumber = (): LineBuilder => aLine().withTexts([aTextWit
 export const aLineWithCeNumber = (): LineBuilder => aLine().withTexts([aTextWithCeNumber().properties]);
 export const aLineWithCasAndCeNumberIn2Texts = (): LineBuilder =>
   aLine().withTexts([aTextWithCasNumber().properties, aTextWithCeNumber().properties]);
-export const aLineWithCasAndCeNumberAndConcentrationIn3Texts = (): LineBuilder =>
-  aLine().withTexts([aTextWithCasNumber().properties, aTextWithCeNumber().properties, aTextWithConcentration().properties]);
 
 //----------------------------------------------------------------------------------------------
 //--------------------------------------- PHYSICAL_STATE ---------------------------------------

--- a/src/topics/engine/__tests__/__snapshots__/fds-engine.service.test.ts.snap
+++ b/src/topics/engine/__tests__/__snapshots__/fds-engine.service.test.ts.snap
@@ -165,6 +165,18 @@ exports[`FdsEngine tests > ExtractDataFromFds tests > should extract data from a
           },
           "value": "> 10 - < 30",
         },
+        "hazards": [
+          {
+            "code": "h304",
+            "metaData": {
+              "startBox": {
+                "pageNumber": 2,
+                "xPositionProportion": 0.6398355192431735,
+                "yPositionProportion": 0.6648422652983657,
+              },
+            },
+          },
+        ],
       },
       {
         "casNumber": undefined,
@@ -410,6 +422,38 @@ exports[`FdsEngine tests > ExtractDataFromFds tests > should extract data from a
           "value": "08062-26-4",
         },
         "ceNumber": undefined,
+        "hazards": [
+          {
+            "code": "h315",
+            "metaData": {
+              "startBox": {
+                "pageNumber": 4,
+                "xPositionProportion": 0.09047619047619047,
+                "yPositionProportion": 0.38922558922558925,
+              },
+            },
+          },
+          {
+            "code": "h400",
+            "metaData": {
+              "startBox": {
+                "pageNumber": 4,
+                "xPositionProportion": 0.7542857142857143,
+                "yPositionProportion": 0.40606060606060607,
+              },
+            },
+          },
+          {
+            "code": "h411",
+            "metaData": {
+              "startBox": {
+                "pageNumber": 4,
+                "xPositionProportion": 0.7542857142857143,
+                "yPositionProportion": 0.41414141414141414,
+              },
+            },
+          },
+        ],
       },
       {
         "casNumber": undefined,
@@ -428,6 +472,28 @@ exports[`FdsEngine tests > ExtractDataFromFds tests > should extract data from a
           },
           "value": "219-145-8",
         },
+        "hazards": [
+          {
+            "code": "h410",
+            "metaData": {
+              "startBox": {
+                "pageNumber": 4,
+                "xPositionProportion": 0.09142857142857143,
+                "yPositionProportion": 0.45521885521885525,
+              },
+            },
+          },
+          {
+            "code": "h301",
+            "metaData": {
+              "startBox": {
+                "pageNumber": 4,
+                "xPositionProportion": 0.5085714285714286,
+                "yPositionProportion": 0.4653198653198653,
+              },
+            },
+          },
+        ],
       },
     ],
     "vaporPressure": null,

--- a/src/topics/engine/__tests__/__snapshots__/fds-engine.service.test.ts.snap
+++ b/src/topics/engine/__tests__/__snapshots__/fds-engine.service.test.ts.snap
@@ -167,7 +167,7 @@ exports[`FdsEngine tests > ExtractDataFromFds tests > should extract data from a
         },
         "hazards": [
           {
-            "code": "h304",
+            "code": "H304",
             "metaData": {
               "startBox": {
                 "pageNumber": 2,
@@ -424,7 +424,7 @@ exports[`FdsEngine tests > ExtractDataFromFds tests > should extract data from a
         "ceNumber": undefined,
         "hazards": [
           {
-            "code": "h315",
+            "code": "H315",
             "metaData": {
               "startBox": {
                 "pageNumber": 4,
@@ -434,7 +434,7 @@ exports[`FdsEngine tests > ExtractDataFromFds tests > should extract data from a
             },
           },
           {
-            "code": "h400",
+            "code": "H400",
             "metaData": {
               "startBox": {
                 "pageNumber": 4,
@@ -444,7 +444,7 @@ exports[`FdsEngine tests > ExtractDataFromFds tests > should extract data from a
             },
           },
           {
-            "code": "h411",
+            "code": "H411",
             "metaData": {
               "startBox": {
                 "pageNumber": 4,
@@ -474,7 +474,7 @@ exports[`FdsEngine tests > ExtractDataFromFds tests > should extract data from a
         },
         "hazards": [
           {
-            "code": "h410",
+            "code": "H410",
             "metaData": {
               "startBox": {
                 "pageNumber": 4,
@@ -484,7 +484,7 @@ exports[`FdsEngine tests > ExtractDataFromFds tests > should extract data from a
             },
           },
           {
-            "code": "h301",
+            "code": "H301",
             "metaData": {
               "startBox": {
                 "pageNumber": 4,

--- a/src/topics/engine/rules/extraction-rules/__tests__/__fixtures__/danger.builder.ts
+++ b/src/topics/engine/rules/extraction-rules/__tests__/__fixtures__/danger.builder.ts
@@ -1,0 +1,18 @@
+import type { IExtractedDanger } from '@padoa/chemical-risk';
+import { BaseBuilder } from '@padoa/meta';
+
+import { RAW_H_DANGER, PAGE_NUMBER, POSITION_PROPORTION_X, POSITION_PROPORTION_Y } from '@topics/engine/__fixtures__/fixtures.constants.js';
+
+export class DangerBuilder extends BaseBuilder<IExtractedDanger> {
+  public withCode = this.withValueFor('code');
+  public withMetaData = this.withValueFor('metaData');
+
+  protected getDefaultValues(): IExtractedDanger {
+    return {
+      code: RAW_H_DANGER,
+      metaData: {
+        startBox: { pageNumber: PAGE_NUMBER, xPositionProportion: POSITION_PROPORTION_X, yPositionProportion: POSITION_PROPORTION_Y },
+      },
+    };
+  }
+}

--- a/src/topics/engine/rules/extraction-rules/__tests__/__fixtures__/danger.mother.ts
+++ b/src/topics/engine/rules/extraction-rules/__tests__/__fixtures__/danger.mother.ts
@@ -1,0 +1,7 @@
+import { RAW_H_DANGER, RAW_P_DANGER } from '@topics/engine/__fixtures__/fixtures.constants.js';
+import { DangerBuilder } from '@topics/engine/rules/extraction-rules/__tests__/__fixtures__/danger.builder.js';
+
+export const aDanger = (): DangerBuilder => new DangerBuilder();
+
+export const aHDanger = (): DangerBuilder => aDanger().withCode(RAW_H_DANGER);
+export const aPDanger = (): DangerBuilder => aDanger().withCode(RAW_P_DANGER);

--- a/src/topics/engine/rules/extraction-rules/__tests__/__fixtures__/substance.builder.ts
+++ b/src/topics/engine/rules/extraction-rules/__tests__/__fixtures__/substance.builder.ts
@@ -2,6 +2,7 @@ import type { IExtractedSubstance } from '@padoa/chemical-risk';
 import { BaseBuilder } from '@padoa/meta';
 
 import {
+  H_DANGER,
   PAGE_NUMBER,
   POSITION_PROPORTION_X,
   POSITION_PROPORTION_Y,
@@ -14,6 +15,7 @@ export class SubstanceBuilder extends BaseBuilder<IExtractedSubstance> {
   public withCasNumber = this.withValueFor('casNumber');
   public withCeNumber = this.withValueFor('ceNumber');
   public withConcentration = this.withValueFor('concentration');
+  public withHazards = this.withValueFor('hazards');
 
   protected getDefaultValues(): IExtractedSubstance {
     const metaData = {
@@ -24,6 +26,7 @@ export class SubstanceBuilder extends BaseBuilder<IExtractedSubstance> {
       casNumber: { value: RAW_CAS_NUMBER, metaData },
       ceNumber: { value: RAW_CE_NUMBER, metaData },
       concentration: { value: RAW_CONCENTRATION_VALUE, metaData },
+      hazards: [{ code: H_DANGER, metaData }],
     };
   }
 }

--- a/src/topics/engine/rules/extraction-rules/__tests__/__fixtures__/substance.builder.ts
+++ b/src/topics/engine/rules/extraction-rules/__tests__/__fixtures__/substance.builder.ts
@@ -2,7 +2,7 @@ import type { IExtractedSubstance } from '@padoa/chemical-risk';
 import { BaseBuilder } from '@padoa/meta';
 
 import {
-  H_DANGER,
+  RAW_H_DANGER,
   PAGE_NUMBER,
   POSITION_PROPORTION_X,
   POSITION_PROPORTION_Y,
@@ -26,7 +26,7 @@ export class SubstanceBuilder extends BaseBuilder<IExtractedSubstance> {
       casNumber: { value: RAW_CAS_NUMBER, metaData },
       ceNumber: { value: RAW_CE_NUMBER, metaData },
       concentration: { value: RAW_CONCENTRATION_VALUE, metaData },
-      hazards: [{ code: H_DANGER, metaData }],
+      hazards: [{ code: RAW_H_DANGER, metaData }],
     };
   }
 }

--- a/src/topics/engine/rules/extraction-rules/__tests__/__fixtures__/substance.mother.ts
+++ b/src/topics/engine/rules/extraction-rules/__tests__/__fixtures__/substance.mother.ts
@@ -2,6 +2,10 @@ import { SubstanceBuilder } from '@topics/engine/rules/extraction-rules/__tests_
 
 export const aSubstance = (): SubstanceBuilder => new SubstanceBuilder();
 
-export const aSubstanceWithCasAndCeNumber = (): SubstanceBuilder => aSubstance().withConcentration(undefined);
-export const aSubstanceWithOnlyACasNumber = (): SubstanceBuilder => aSubstance().withCeNumber(undefined).withConcentration(undefined);
-export const aSubstanceWithOnlyACeNumber = (): SubstanceBuilder => aSubstance().withCasNumber(undefined).withConcentration(undefined);
+export const aSubstanceWithCasAndCeNumber = (): SubstanceBuilder => aSubstance().withConcentration(undefined).withHazards(undefined);
+export const aSubstanceWithOnlyACasNumber = (): SubstanceBuilder =>
+  aSubstance().withCeNumber(undefined).withConcentration(undefined).withHazards(undefined);
+export const aSubstanceWithOnlyACeNumber = (): SubstanceBuilder =>
+  aSubstance().withCasNumber(undefined).withConcentration(undefined).withHazards(undefined);
+
+export const aSubstanceWithoutHazards = (): SubstanceBuilder => aSubstance().withHazards(undefined);

--- a/src/topics/engine/rules/extraction-rules/__tests__/dangers-rules.service.test.ts
+++ b/src/topics/engine/rules/extraction-rules/__tests__/dangers-rules.service.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from 'vitest';
-import _ from 'lodash';
 import type { IExtractedDanger, IMetaData } from '@padoa/chemical-risk';
 
 import { anEmptyFdsTreeWithAllSections, aFdsTreeWithAllSectionsWithoutUsefulInfo, aFdsTree } from '@topics/engine/__fixtures__/fds-tree.mother.js';
@@ -13,90 +12,6 @@ import { aPosition } from '@topics/engine/__fixtures__/position.mother.js';
 
 describe('DangersRulesService tests', () => {
   const metaData: IMetaData = { startBox: aPosition().properties };
-
-  describe('Regexps tests', () => {
-    describe('HAZARDS_REGEX', () => {
-      it.each<{ input: string; expected: string }>([
-        { input: 'h350i', expected: 'h350i' },
-        { input: 'h 350i', expected: 'h 350i' },
-        { input: 'h360f', expected: 'h360f' },
-        { input: 'h 360f', expected: 'h 360f' },
-        { input: 'h360d', expected: 'h360d' },
-        { input: 'h 360d', expected: 'h 360d' },
-        { input: 'h360fd', expected: 'h360fd' },
-        { input: 'h 360fd', expected: 'h 360fd' },
-        { input: 'h360df', expected: 'h360df' },
-        { input: 'h 360df', expected: 'h 360df' },
-        { input: 'h361f', expected: 'h361f' },
-        { input: 'h 361f', expected: 'h 361f' },
-        { input: 'h361d', expected: 'h361d' },
-        { input: 'h 361d', expected: 'h 361d' },
-        { input: 'h361fd', expected: 'h361fd' },
-        { input: 'h 361fd', expected: 'h 361fd' },
-        { input: 'h200', expected: 'h200' },
-        { input: 'h300', expected: 'h300' },
-        { input: 'h400', expected: 'h400' },
-        { input: 'h500', expected: undefined },
-        { input: 'h600', expected: undefined },
-        { input: 'h700', expected: undefined },
-        { input: 'h800', expected: undefined },
-        { input: 'h900', expected: undefined },
-        { input: '360f', expected: undefined },
-        { input: '250', expected: undefined },
-        { input: 'h2', expected: undefined },
-        { input: 'h25', expected: undefined },
-      ])('should return $expected with input $input', ({ input, expected }) => {
-        expect(_.first(input.match(DangersRulesService.HAZARDS_REGEX))).toEqual(expected);
-      });
-    });
-
-    describe('PRECAUTION_REGEX', () => {
-      it.each<{ input: string; expected: string }>([
-        { input: 'p150', expected: 'p150' },
-        { input: 'p  350', expected: 'p  350' },
-        { input: 'p421', expected: 'p421' },
-        { input: 'p150 + p200', expected: 'p150 + p200' },
-        { input: 'p300 + p 400 + p500', expected: 'p300 + p 400 + p500' },
-        { input: 'p 250 +', expected: 'p 250 +' },
-        { input: 'p  350 + p 450 + p550 +', expected: 'p  350 + p 450 + p550 +' },
-        { input: 'p250 +', expected: 'p250 +' }, // TODO: improve regex to avoid this case
-        { input: 'p250 + p', expected: 'p250 + ' }, // TODO: improve regex to avoid this case
-        { input: 'p250 + p600', expected: 'p250 + ' }, // TODO: improve regex to avoid this case
-        { input: 'p600', expected: undefined },
-        { input: 'p700', expected: undefined },
-        { input: 'p800', expected: undefined },
-        { input: 'p900', expected: undefined },
-        { input: '600', expected: undefined },
-        { input: '600', expected: undefined },
-      ])('should return $expected with input $input', ({ input, expected }) => {
-        expect(_.first(input.match(DangersRulesService.PRECAUTION_REGEX))).toEqual(expected);
-      });
-    });
-
-    describe('EUROPEAN_HAZARDS_REGEX', () => {
-      it.each<{ input: string; expected: string }>([
-        { input: 'euh200', expected: 'euh200' },
-        { input: 'euh  250', expected: 'euh  250' },
-        { input: 'euh401', expected: 'euh401' },
-        { input: 'euh  401', expected: 'euh  401' },
-        { input: 'euh021', expected: 'euh021' },
-        { input: 'euh150', expected: undefined },
-        { input: 'euh 350', expected: undefined },
-        { input: 'euh 450', expected: undefined },
-        { input: 'euh 550', expected: undefined },
-        { input: 'euh 650', expected: undefined },
-        { input: 'euh 750', expected: undefined },
-        { input: 'euh 850', expected: undefined },
-        { input: 'euh 950', expected: undefined },
-        { input: 'euh400', expected: undefined },
-        { input: '240', expected: undefined },
-        { input: 'e240', expected: undefined },
-        { input: 'eu240', expected: undefined },
-      ])('should return $expected with input $input', ({ input, expected }) => {
-        expect(_.first(input.match(DangersRulesService.EUROPEAN_HAZARDS_REGEX))).toEqual(expected);
-      });
-    });
-  });
 
   describe('GetDangers tests', () => {
     it.each<[{ message: string; fdsTree: IFdsTree; expected: IExtractedDanger[] }]>([

--- a/src/topics/engine/rules/extraction-rules/__tests__/dangers.regex.test.ts
+++ b/src/topics/engine/rules/extraction-rules/__tests__/dangers.regex.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import _ from 'lodash';
+
+import { EUROPEAN_HAZARDS_REGEX, HAZARDS_REGEX, PRECAUTION_REGEX } from '@topics/engine/rules/extraction-rules/dangers.regex.js';
+
+describe('DangersRulesService tests', () => {
+  describe('HAZARDS_REGEX', () => {
+    it.each<{ input: string; expected: string }>([
+      { input: 'h350i', expected: 'h350i' },
+      { input: 'h 350i', expected: 'h 350i' },
+      { input: 'h360f', expected: 'h360f' },
+      { input: 'h 360f', expected: 'h 360f' },
+      { input: 'h360d', expected: 'h360d' },
+      { input: 'h 360d', expected: 'h 360d' },
+      { input: 'h360fd', expected: 'h360fd' },
+      { input: 'h 360fd', expected: 'h 360fd' },
+      { input: 'h360df', expected: 'h360df' },
+      { input: 'h 360df', expected: 'h 360df' },
+      { input: 'h361f', expected: 'h361f' },
+      { input: 'h 361f', expected: 'h 361f' },
+      { input: 'h361d', expected: 'h361d' },
+      { input: 'h 361d', expected: 'h 361d' },
+      { input: 'h361fd', expected: 'h361fd' },
+      { input: 'h 361fd', expected: 'h 361fd' },
+      { input: 'h200', expected: 'h200' },
+      { input: 'h300', expected: 'h300' },
+      { input: 'h400', expected: 'h400' },
+      { input: 'h500', expected: undefined },
+      { input: 'h600', expected: undefined },
+      { input: 'h700', expected: undefined },
+      { input: 'h800', expected: undefined },
+      { input: 'h900', expected: undefined },
+      { input: '360f', expected: undefined },
+      { input: '250', expected: undefined },
+      { input: 'h2', expected: undefined },
+      { input: 'h25', expected: undefined },
+      { input: 'euh250', expected: undefined },
+    ])('should return $expected with input $input', ({ input, expected }) => {
+      expect(_.first(input.match(HAZARDS_REGEX))).toEqual(expected);
+    });
+  });
+
+  describe('PRECAUTION_REGEX', () => {
+    it.each<{ input: string; expected: string }>([
+      { input: 'p150', expected: 'p150' },
+      { input: 'p  350', expected: 'p  350' },
+      { input: 'p421', expected: 'p421' },
+      { input: 'p150 + p200', expected: 'p150 + p200' },
+      { input: 'p300 + p 400 + p500', expected: 'p300 + p 400 + p500' },
+      { input: 'p 250 +', expected: 'p 250 +' },
+      { input: 'p  350 + p 450 + p550 +', expected: 'p  350 + p 450 + p550 +' },
+      { input: 'p250 +', expected: 'p250 +' }, // TODO: improve regex to avoid this case
+      { input: 'p250 + p', expected: 'p250 + ' }, // TODO: improve regex to avoid this case
+      { input: 'p250 + p600', expected: 'p250 + ' }, // TODO: improve regex to avoid this case
+      { input: 'p600', expected: undefined },
+      { input: 'p700', expected: undefined },
+      { input: 'p800', expected: undefined },
+      { input: 'p900', expected: undefined },
+      { input: '600', expected: undefined },
+      { input: '600', expected: undefined },
+    ])('should return $expected with input $input', ({ input, expected }) => {
+      expect(_.first(input.match(PRECAUTION_REGEX))).toEqual(expected);
+    });
+  });
+
+  describe('EUROPEAN_HAZARDS_REGEX', () => {
+    it.each<{ input: string; expected: string }>([
+      { input: 'euh200', expected: 'euh200' },
+      { input: 'euh  250', expected: 'euh  250' },
+      { input: 'euh401', expected: 'euh401' },
+      { input: 'euh  401', expected: 'euh  401' },
+      { input: 'euh021', expected: 'euh021' },
+      { input: 'euh150', expected: undefined },
+      { input: 'euh 350', expected: undefined },
+      { input: 'euh 450', expected: undefined },
+      { input: 'euh 550', expected: undefined },
+      { input: 'euh 650', expected: undefined },
+      { input: 'euh 750', expected: undefined },
+      { input: 'euh 850', expected: undefined },
+      { input: 'euh 950', expected: undefined },
+      { input: 'euh400', expected: undefined },
+      { input: '240', expected: undefined },
+      { input: 'e240', expected: undefined },
+      { input: 'eu240', expected: undefined },
+    ])('should return $expected with input $input', ({ input, expected }) => {
+      expect(_.first(input.match(EUROPEAN_HAZARDS_REGEX))).toEqual(expected);
+    });
+  });
+});

--- a/src/topics/engine/rules/extraction-rules/__tests__/substance/concentration-rules.service.test.ts
+++ b/src/topics/engine/rules/extraction-rules/__tests__/substance/concentration-rules.service.test.ts
@@ -1,12 +1,10 @@
-import type { SpyInstance } from 'vitest';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import _ from 'lodash';
 import type { IExtractedConcentration } from '@padoa/chemical-risk';
 
-import type { ILine, IStroke, IText } from '@topics/engine/model/fds.model.js';
+import type { IText } from '@topics/engine/model/fds.model.js';
 import { ConcentrationRulesService } from '@topics/engine/rules/extraction-rules/substance/concentration-rules.service.js';
 import { aText, aTextWithConcentration } from '@topics/engine/__fixtures__/text.mother.js';
-import { TableExtractionService } from '@topics/engine/rules/extraction-rules/substance/table-extraction.service.js';
 import { aConcentration } from '@topics/engine/rules/extraction-rules/__tests__/__fixtures__/concentration.mother.js';
 
 describe('ConcentrationRulesService tests', () => {
@@ -114,19 +112,6 @@ describe('ConcentrationRulesService tests', () => {
     });
 
     describe('getConcentrations tests', () => {
-      let getTableVerticalStrokesSpy: SpyInstance<[strokes: IStroke[]], IStroke[]>;
-      let splitLinesInColumnsSpy: SpyInstance<[line: ILine[], tableVerticalStrokes: IStroke[]], IText[][][]>;
-
-      beforeEach(() => {
-        getTableVerticalStrokesSpy = vi.spyOn(TableExtractionService, 'getTableVerticalStrokes');
-        splitLinesInColumnsSpy = vi.spyOn(TableExtractionService, 'splitLinesInColumns');
-      });
-
-      afterEach(() => {
-        getTableVerticalStrokesSpy.mockRestore();
-        splitLinesInColumnsSpy.mockRestore();
-      });
-
       it.each<{ message: string; linesSplittedByColumns: IText[][][]; expected: IExtractedConcentration[] }>([
         {
           message: 'should return an empty list when there is no text',
@@ -147,11 +132,7 @@ describe('ConcentrationRulesService tests', () => {
           expected: [aConcentration().properties, aConcentration().properties],
         },
       ])('$message', ({ linesSplittedByColumns, expected }) => {
-        splitLinesInColumnsSpy.mockImplementation(() => linesSplittedByColumns);
-
-        expect(ConcentrationRulesService.getConcentrations([], { strokes: [] })).toEqual(expected);
-        expect(getTableVerticalStrokesSpy).toHaveBeenCalledOnce();
-        expect(splitLinesInColumnsSpy).toHaveBeenCalledOnce();
+        expect(ConcentrationRulesService.getConcentrations(linesSplittedByColumns)).toEqual(expected);
       });
     });
   });

--- a/src/topics/engine/rules/extraction-rules/__tests__/substance/substance-hazards-rules.service.test.ts
+++ b/src/topics/engine/rules/extraction-rules/__tests__/substance/substance-hazards-rules.service.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+
+import type { IExtractedDanger, IText } from '@topics/engine/model/fds.model.js';
+import { aText, aTextWithEuhDanger, aTextWithHDanger, aTextWithPDanger } from '@topics/engine/__fixtures__/text.mother.js';
+import { aDanger, aHDanger } from '@topics/engine/rules/extraction-rules/__tests__/__fixtures__/danger.mother.js';
+import { SubstanceHazardsRulesService } from '@topics/engine/rules/extraction-rules/substance/substance-hazards-rules.service.js';
+
+describe('SubstanceHazardsRulesService tests', () => {
+  describe('getHazardsInColumn tests', () => {
+    it.each<{ message: string; lines: IText[][]; expected: IExtractedDanger[] }>([
+      {
+        message: 'should return an empty list when given an empty lines',
+        lines: [],
+        expected: [],
+      },
+      {
+        message: 'should not return anything if no text has dangers',
+        lines: [[aText().properties], []],
+        expected: [],
+      },
+      {
+        message: 'should return a hazard if a line contains a hazard',
+        lines: [[aTextWithHDanger().properties], []],
+        expected: [aHDanger().properties],
+      },
+      {
+        message: 'should not return a precaution if a line contains a precaution',
+        lines: [[aTextWithPDanger().properties], []],
+        expected: [],
+      },
+      {
+        message: 'should not return an european hazard if a line contains an european hazard',
+        lines: [[aTextWithEuhDanger().properties], []],
+        expected: [],
+      },
+      {
+        message: 'should return a hazard if a text in a line contains a hazard',
+        lines: [[aText().properties, aTextWithHDanger().properties], []],
+        expected: [aHDanger().properties],
+      },
+      {
+        message: 'should return multiple hazards if multiple lines have a hazard',
+        lines: [[aTextWithHDanger().properties], [aText().withContent('h300').properties]],
+        expected: [aHDanger().properties, aDanger().withCode('h300').properties],
+      },
+      {
+        message: 'should return multiple hazards if a text has multiple hazards',
+        lines: [[aText().withContent('h300 and some other text h400').properties], []],
+        expected: [aDanger().withCode('h300').properties, aDanger().withCode('h400').properties],
+      },
+    ])('$message', ({ lines, expected }) => {
+      expect(SubstanceHazardsRulesService.getHazardsInColumn(lines)).toEqual(expected);
+    });
+  });
+
+  describe('getHazards tests', () => {
+    it.each<{ message: string; linesSplittedByColumns: IText[][][]; expected: IExtractedDanger[] }>([
+      {
+        message: 'should return an empty list when there is no text',
+        linesSplittedByColumns: [[]],
+        expected: [],
+      },
+      {
+        message: 'should return hazards of a column',
+        linesSplittedByColumns: [[[aTextWithHDanger().properties]], [[]]],
+        expected: [aHDanger().properties],
+      },
+      {
+        message: 'should return hazards found in the column with most hazards',
+        linesSplittedByColumns: [
+          [[aText().withContent('h200').properties]],
+          [[aTextWithHDanger().properties], [aText().withContent('h300').properties]],
+        ],
+        expected: [aHDanger().properties, aDanger().withCode('h300').properties],
+      },
+    ])('$message', ({ linesSplittedByColumns, expected }) => {
+      expect(SubstanceHazardsRulesService.getHazards(linesSplittedByColumns)).toEqual(expected);
+    });
+  });
+});

--- a/src/topics/engine/rules/extraction-rules/__tests__/substance/substance-hazards-rules.service.test.ts
+++ b/src/topics/engine/rules/extraction-rules/__tests__/substance/substance-hazards-rules.service.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
+import type { IExtractedDanger } from '@padoa/chemical-risk';
 
-import type { IExtractedDanger, IText } from '@topics/engine/model/fds.model.js';
+import type { IText } from '@topics/engine/model/fds.model.js';
 import { aText, aTextWithEuhDanger, aTextWithHDanger, aTextWithPDanger } from '@topics/engine/__fixtures__/text.mother.js';
 import { aDanger, aHDanger } from '@topics/engine/rules/extraction-rules/__tests__/__fixtures__/danger.mother.js';
 import { SubstanceHazardsRulesService } from '@topics/engine/rules/extraction-rules/substance/substance-hazards-rules.service.js';
@@ -40,13 +41,13 @@ describe('SubstanceHazardsRulesService tests', () => {
       },
       {
         message: 'should return multiple hazards if multiple lines have a hazard',
-        lines: [[aTextWithHDanger().properties], [aText().withContent('h300').properties]],
-        expected: [aHDanger().properties, aDanger().withCode('h300').properties],
+        lines: [[aTextWithHDanger().properties], [aText().withContent('H300').properties]],
+        expected: [aHDanger().properties, aDanger().withCode('H300').properties],
       },
       {
         message: 'should return multiple hazards if a text has multiple hazards',
-        lines: [[aText().withContent('h300 and some other text h400').properties], []],
-        expected: [aDanger().withCode('h300').properties, aDanger().withCode('h400').properties],
+        lines: [[aText().withContent('H300 and some other text H400').properties], []],
+        expected: [aDanger().withCode('H300').properties, aDanger().withCode('H400').properties],
       },
     ])('$message', ({ lines, expected }) => {
       expect(SubstanceHazardsRulesService.getHazardsInColumn(lines)).toEqual(expected);
@@ -68,10 +69,10 @@ describe('SubstanceHazardsRulesService tests', () => {
       {
         message: 'should return hazards found in the column with most hazards',
         linesSplittedByColumns: [
-          [[aText().withContent('h200').properties]],
-          [[aTextWithHDanger().properties], [aText().withContent('h300').properties]],
+          [[aText().withContent('H200').properties]],
+          [[aTextWithHDanger().properties], [aText().withContent('H300').properties]],
         ],
-        expected: [aHDanger().properties, aDanger().withCode('h300').properties],
+        expected: [aHDanger().properties, aDanger().withCode('H300').properties],
       },
     ])('$message', ({ linesSplittedByColumns, expected }) => {
       expect(SubstanceHazardsRulesService.getHazards(linesSplittedByColumns)).toEqual(expected);

--- a/src/topics/engine/rules/extraction-rules/__tests__/substances-rules.service.test.ts
+++ b/src/topics/engine/rules/extraction-rules/__tests__/substances-rules.service.test.ts
@@ -1,9 +1,10 @@
 import type { SpyInstance } from 'vitest';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { IExtractedConcentration, IExtractedSubstance } from '@padoa/chemical-risk';
+import type { IExtractedConcentration, IExtractedDanger, IExtractedSubstance } from '@padoa/chemical-risk';
 
-import type { IFdsTree, ILine, IStroke } from '@topics/engine/model/fds.model.js';
+import type { IFdsTree, ILine, IText } from '@topics/engine/model/fds.model.js';
 import { SubstancesRulesService } from '@topics/engine/rules/extraction-rules/substances-rules.service.js';
+import { RAW_CONCENTRATION_VALUE, INCREMENT_VALUE, PAGE_NUMBER, POSITION_PROPORTION_Y } from '@topics/engine/__fixtures__/fixtures.constants.js';
 import {
   aFdsTree,
   aFdsTreeWithAllSectionsWithUsefulInfo,
@@ -11,13 +12,18 @@ import {
 } from '@topics/engine/__fixtures__/fds-tree.mother.js';
 import { CasAndCeRulesService } from '@topics/engine/rules/extraction-rules/substance/cas-and-ce-rules.service.js';
 import {
-  aSubstanceWithCasAndCeNumber,
+  aSubstance,
   aSubstanceWithOnlyACasNumber,
   aSubstanceWithOnlyACeNumber,
+  aSubstanceWithoutHazards,
 } from '@topics/engine/rules/extraction-rules/__tests__/__fixtures__/substance.mother.js';
 import { aConcentration } from '@topics/engine/rules/extraction-rules/__tests__/__fixtures__/concentration.mother.js';
 import { ConcentrationRulesService } from '@topics/engine/rules/extraction-rules/substance/concentration-rules.service.js';
-import { RAW_CONCENTRATION_VALUE } from '@topics/engine/__fixtures__/fixtures.constants.js';
+import { SubstanceHazardsRulesService } from '@topics/engine/rules/extraction-rules/substance/substance-hazards-rules.service.js';
+import { aDanger, aHDanger } from '@topics/engine/rules/extraction-rules/__tests__/__fixtures__/danger.mother.js';
+import { aCasNumber } from '@topics/engine/rules/extraction-rules/__tests__/__fixtures__/cas-number.mother.js';
+import { aPosition } from '@topics/engine/__fixtures__/position.mother.js';
+import type { SubstanceBuilder } from '@topics/engine/rules/extraction-rules/__tests__/__fixtures__/substance.builder.js';
 
 describe('SubstancesRulesService tests', () => {
   describe('assignConcentrationToSubstance tests', () => {
@@ -54,28 +60,90 @@ describe('SubstancesRulesService tests', () => {
         expected: [aSubstanceWithOnlyACasNumber().properties, aSubstanceWithOnlyACeNumber().properties],
       },
     ])('$message', ({ substances, concentrations, expected }) => {
-      expect(SubstancesRulesService.assignConcentrationToSubstance(substances, concentrations)).toEqual(expected);
+      expect(SubstancesRulesService.assignConcentrationsToSubstances(substances, concentrations)).toEqual(expected);
+    });
+  });
+
+  describe('assignHazardsToSubstances tests', () => {
+    const aMetaData1LineBelow = { startBox: aPosition().withYPositionProportion(POSITION_PROPORTION_Y + INCREMENT_VALUE).properties };
+    const aMetaData1PageBelow = { startBox: aPosition().withPageNumber(PAGE_NUMBER + 1).properties };
+    const aSubstanceStarting1LineBelow = (): SubstanceBuilder =>
+      aSubstanceWithOnlyACasNumber().withCasNumber(aCasNumber().withMetaData(aMetaData1LineBelow).properties);
+    const aSubstanceStarting1PageBelow = (): SubstanceBuilder =>
+      aSubstanceWithOnlyACasNumber().withCasNumber(aCasNumber().withMetaData(aMetaData1PageBelow).properties);
+
+    it.each<{ message: string; substances: IExtractedSubstance[]; hazards: IExtractedDanger[]; expected: IExtractedSubstance[] }>([
+      {
+        message: 'should return an empty list when there is no substance',
+        substances: [],
+        hazards: [],
+        expected: [],
+      },
+      {
+        message: 'should return substances without hazards when there are substances but no hazards',
+        substances: [aSubstanceWithoutHazards().properties],
+        hazards: [],
+        expected: [aSubstanceWithoutHazards().properties],
+      },
+      {
+        message: 'should return substance with hazards',
+        substances: [aSubstanceWithoutHazards().properties],
+        hazards: [aHDanger().properties, aDanger().withCode('h300').properties],
+        expected: [aSubstance().withHazards([aHDanger().properties, aDanger().withCode('h300').properties]).properties],
+      },
+      {
+        message: 'should return substance with hazards affected to the correct substances when hazards are on multiple lines on the same page',
+        substances: [aSubstanceWithoutHazards().properties, aSubstanceStarting1LineBelow().properties],
+        hazards: [
+          aHDanger().properties,
+          aDanger().withCode('h300').properties,
+          aDanger().withCode('h400').withMetaData(aMetaData1LineBelow).properties,
+        ],
+        expected: [
+          aSubstance().withHazards([aHDanger().properties, aDanger().withCode('h300').properties]).properties,
+          aSubstanceStarting1LineBelow().withHazards([aDanger().withCode('h400').withMetaData(aMetaData1LineBelow).properties]).properties,
+        ],
+      },
+      {
+        message: 'should return substance with hazards affected to the correct substances when hazards are on a different page',
+        substances: [aSubstanceWithoutHazards().properties, aSubstanceStarting1PageBelow().properties],
+        hazards: [
+          aHDanger().properties,
+          aDanger().withCode('h300').properties,
+          aDanger().withCode('h400').withMetaData(aMetaData1PageBelow).properties,
+        ],
+        expected: [
+          aSubstance().withHazards([aHDanger().properties, aDanger().withCode('h300').properties]).properties,
+          aSubstanceStarting1PageBelow().withHazards([aDanger().withCode('h400').withMetaData(aMetaData1PageBelow).properties]).properties,
+        ],
+      },
+    ])('$message', ({ substances, hazards, expected }) => {
+      expect(SubstancesRulesService.assignHazardsToSubstances(substances, hazards)).toEqual(expected);
     });
   });
 
   describe('GetSubstances tests', () => {
     let getSubstancesCasAndCeSpy: SpyInstance<[lines: ILine[]], Pick<IExtractedSubstance, 'casNumber' | 'ceNumber'>[]>;
-    let getConcentrationsSpy: SpyInstance<[line: ILine[], { strokes: IStroke[] }], IExtractedConcentration[]>;
-    let assignConcentrationToSubstanceSpy: SpyInstance<
-      [substances: IExtractedSubstance[], concentration: IExtractedConcentration[]],
+    let getConcentrationsSpy: SpyInstance<[linesSplittedByColumns: IText[][][]], IExtractedConcentration[]>;
+    let assignConcentrationsToSubstancesSpy: SpyInstance<
+      [substances: IExtractedSubstance[], concentrations: IExtractedConcentration[]],
       IExtractedSubstance[]
     >;
+    let getHazardsSpy: SpyInstance<[linesSplittedByColumns: IText[][][]], IExtractedDanger[]>;
+    let assignHazardsToSubstancesSpy: SpyInstance<[substances: IExtractedSubstance[], concentrations: IExtractedDanger[]], IExtractedSubstance[]>;
 
     beforeEach(() => {
       getSubstancesCasAndCeSpy = vi.spyOn(CasAndCeRulesService, 'getSubstancesCasAndCe');
       getConcentrationsSpy = vi.spyOn(ConcentrationRulesService, 'getConcentrations');
-      assignConcentrationToSubstanceSpy = vi.spyOn(SubstancesRulesService, 'assignConcentrationToSubstance');
+      assignConcentrationsToSubstancesSpy = vi.spyOn(SubstancesRulesService, 'assignConcentrationsToSubstances');
+      getHazardsSpy = vi.spyOn(SubstanceHazardsRulesService, 'getHazards');
+      assignHazardsToSubstancesSpy = vi.spyOn(SubstancesRulesService, 'assignHazardsToSubstances');
     });
 
     afterEach(() => {
       getSubstancesCasAndCeSpy.mockRestore();
       getConcentrationsSpy.mockRestore();
-      assignConcentrationToSubstanceSpy.mockRestore();
+      assignConcentrationsToSubstancesSpy.mockRestore();
     });
 
     it.each<{ message: string; fdsTree: IFdsTree; expected: IExtractedSubstance[] }>([
@@ -92,13 +160,15 @@ describe('SubstancesRulesService tests', () => {
       {
         message: 'should return substances when given a fdsTree with substances and concentration',
         fdsTree: aFdsTreeWithAllSectionsWithUsefulInfo().properties,
-        expected: [aSubstanceWithCasAndCeNumber().withConcentration(aConcentration().properties).properties],
+        expected: [aSubstance().properties],
       },
     ])('$message', ({ fdsTree, expected }) => {
       expect(SubstancesRulesService.getSubstances(fdsTree)).toEqual(expected);
       expect(getSubstancesCasAndCeSpy).toHaveBeenCalledOnce();
       expect(getConcentrationsSpy).toHaveBeenCalledOnce();
-      expect(assignConcentrationToSubstanceSpy).toHaveBeenCalledOnce();
+      expect(assignConcentrationsToSubstancesSpy).toHaveBeenCalledOnce();
+      expect(getHazardsSpy).toHaveBeenCalledOnce();
+      expect(assignHazardsToSubstancesSpy).toHaveBeenCalledOnce();
     });
   });
 });

--- a/src/topics/engine/rules/extraction-rules/dangers-rules.service.ts
+++ b/src/topics/engine/rules/extraction-rules/dangers-rules.service.ts
@@ -3,14 +3,9 @@ import type { IExtractedDanger } from '@padoa/chemical-risk';
 
 import type { IFdsTree } from '@topics/engine/model/fds.model.js';
 import { ExtractionToolsService } from '@topics/engine/rules/extraction-rules/extraction-tools.service.js';
+import { EUROPEAN_HAZARDS_REGEX, HAZARDS_REGEX, PRECAUTION_REGEX } from '@topics/engine/rules/extraction-rules/dangers.regex.js';
 
 export class DangersRulesService {
-  private static readonly CUSTOM_HAZARDS_REGEX = ['h\\s*350i', 'h\\s*360f[d]?', 'h\\s*360d[f]?', 'h\\s*361f[d]?', 'h\\s*361d'];
-
-  public static readonly HAZARDS_REGEX = `(${this.CUSTOM_HAZARDS_REGEX.join(')|(')})|(h\\s*[2-4]\\d{2})`;
-  public static readonly PRECAUTION_REGEX = '(((p\\s*[1-5]\\d{2})\\s*\\+?\\s*)+)';
-  public static readonly EUROPEAN_HAZARDS_REGEX = '(euh\\s*[02]\\d{2})|(euh\\s*401)';
-
   public static getDangers(fdsTree: IFdsTree): IExtractedDanger[] {
     const linesToSearchIn = fdsTree[2]?.subsections?.[2]?.lines;
     const infoInEachLine = _.map(linesToSearchIn, ({ texts, startBox, endBox }) => {
@@ -24,7 +19,7 @@ export class DangersRulesService {
       return { cleanLineText, rawLineText, startBox, endBox };
     });
 
-    const dangersRegex = new RegExp(`${this.EUROPEAN_HAZARDS_REGEX}|${this.HAZARDS_REGEX}|${this.PRECAUTION_REGEX}`, 'g');
+    const dangersRegex = new RegExp(`${EUROPEAN_HAZARDS_REGEX}|${HAZARDS_REGEX}|${PRECAUTION_REGEX}`, 'g');
     return _(infoInEachLine)
       .map((lineInfo) => {
         const { cleanLineText, rawLineText, startBox, endBox } = lineInfo;

--- a/src/topics/engine/rules/extraction-rules/dangers.regex.ts
+++ b/src/topics/engine/rules/extraction-rules/dangers.regex.ts
@@ -1,0 +1,5 @@
+export const CUSTOM_HAZARDS_REGEX = ['h\\s*350i', 'h\\s*360f[d]?', 'h\\s*360d[f]?', 'h\\s*361f[d]?', 'h\\s*361d'];
+
+export const HAZARDS_REGEX = `(?<!eu)((${CUSTOM_HAZARDS_REGEX.join(')|(')})|(h\\s*[2-4]\\d{2}))`;
+export const PRECAUTION_REGEX = '(((p\\s*[1-5]\\d{2})\\s*\\+?\\s*)+)';
+export const EUROPEAN_HAZARDS_REGEX = '(euh\\s*[02]\\d{2})|(euh\\s*401)';

--- a/src/topics/engine/rules/extraction-rules/substance/concentration-rules.service.ts
+++ b/src/topics/engine/rules/extraction-rules/substance/concentration-rules.service.ts
@@ -1,15 +1,12 @@
 import _ from 'lodash';
 import type { IExtractedConcentration } from '@padoa/chemical-risk';
 
-import type { ILine, IStroke, IText } from '@topics/engine/model/fds.model.js';
-import { TableExtractionService } from '@topics/engine/rules/extraction-rules/substance/table-extraction.service.js';
+import type { IText } from '@topics/engine/model/fds.model.js';
 import { CommonRegexRulesService } from '@topics/engine/rules/extraction-rules/common-regex-rules.service.js';
 import { TextCleanerService } from '@topics/engine/text-cleaner.service.js';
 
 export class ConcentrationRulesService {
-  public static getConcentrations(linesToSearchIn: ILine[], { strokes }: { strokes: IStroke[] }): IExtractedConcentration[] {
-    const tableVerticalStrokes = TableExtractionService.getTableVerticalStrokes(strokes);
-    const linesSplittedByColumns = TableExtractionService.splitLinesInColumns(linesToSearchIn, tableVerticalStrokes);
+  public static getConcentrations(linesSplittedByColumns: IText[][][]): IExtractedConcentration[] {
     const concentrationByColumns = _.map(linesSplittedByColumns, (lines) => this.getConcentrationsInColumn(lines));
     return _(concentrationByColumns)
       .maxBy('length')

--- a/src/topics/engine/rules/extraction-rules/substance/substance-hazards-rules.service.ts
+++ b/src/topics/engine/rules/extraction-rules/substance/substance-hazards-rules.service.ts
@@ -1,0 +1,30 @@
+import _ from 'lodash';
+
+import type { IExtractedDanger, IText } from '@topics/engine/model/fds.model.js';
+import { HAZARDS_REGEX } from '@topics/engine/rules/extraction-rules/dangers.regex.js';
+
+export class SubstanceHazardsRulesService {
+  public static getHazards(linesSplittedByColumns: IText[][][]): IExtractedDanger[] {
+    const hazardsByColumns = _.map(linesSplittedByColumns, (lines) => this.getHazardsInColumn(lines));
+    return _.maxBy(hazardsByColumns, 'length');
+  }
+
+  public static getHazardsInColumn(lines: IText[][]): IExtractedDanger[] {
+    return _(lines)
+      .map((texts) => {
+        const text = texts.map(({ content }) => content).join('');
+        const hazardsCodes = this.getHazardsCodes(text);
+        return _.map(hazardsCodes, (code) => ({
+          code: _.trim(code),
+          metaData: { startBox: _.pick(texts[0], ['pageNumber', 'xPositionProportion', 'yPositionProportion']) },
+        }));
+      })
+      .flatten()
+      .uniqBy('code')
+      .value();
+  }
+
+  public static getHazardsCodes(text: string): string[] {
+    return text.match(new RegExp(HAZARDS_REGEX, 'g')) || [];
+  }
+}

--- a/src/topics/engine/rules/extraction-rules/substances-rules.service.ts
+++ b/src/topics/engine/rules/extraction-rules/substances-rules.service.ts
@@ -1,24 +1,58 @@
 import _ from 'lodash';
-import type { IExtractedConcentration, IExtractedSubstance } from '@padoa/chemical-risk';
+import type { IExtractedConcentration, IExtractedDanger, IExtractedSubstance, IPosition } from '@padoa/chemical-risk';
 
 import type { IFdsTree } from '@topics/engine/model/fds.model.js';
 import { CasAndCeRulesService } from '@topics/engine/rules/extraction-rules/substance/cas-and-ce-rules.service.js';
 import { ConcentrationRulesService } from '@topics/engine/rules/extraction-rules/substance/concentration-rules.service.js';
+import { SubstanceHazardsRulesService } from '@topics/engine/rules/extraction-rules/substance/substance-hazards-rules.service.js';
+import { TableExtractionService } from '@topics/engine/rules/extraction-rules/substance/table-extraction.service.js';
 
 export class SubstancesRulesService {
   public static getSubstances(fdsTree: IFdsTree): IExtractedSubstance[] {
     const linesToSearchIn = [...(fdsTree[3]?.subsections?.[1]?.lines || []), ...(fdsTree[3]?.subsections?.[2]?.lines || [])];
     const strokes = [...(fdsTree[3]?.subsections?.[1]?.strokes || []), ...(fdsTree[3]?.subsections?.[2]?.strokes || [])];
     const substancesCasAndCe = CasAndCeRulesService.getSubstancesCasAndCe(linesToSearchIn);
-    const concentrations = ConcentrationRulesService.getConcentrations(linesToSearchIn, { strokes });
-    const res = this.assignConcentrationToSubstance(substancesCasAndCe, concentrations);
-    return res;
+
+    const tableVerticalStrokes = TableExtractionService.getTableVerticalStrokes(strokes);
+    const linesSplittedByColumns = TableExtractionService.splitLinesInColumns(linesToSearchIn, tableVerticalStrokes);
+
+    const concentrations = ConcentrationRulesService.getConcentrations(linesSplittedByColumns);
+    const substancesWithConcentrations = this.assignConcentrationsToSubstances(substancesCasAndCe, concentrations);
+
+    const hazards = SubstanceHazardsRulesService.getHazards(linesSplittedByColumns);
+    return this.assignHazardsToSubstances(substancesWithConcentrations, hazards);
   }
 
-  public static assignConcentrationToSubstance(substances: IExtractedSubstance[], concentrations: IExtractedConcentration[]): IExtractedSubstance[] {
+  public static assignConcentrationsToSubstances(
+    substances: IExtractedSubstance[],
+    concentrations: IExtractedConcentration[],
+  ): IExtractedSubstance[] {
     const nbConcentrationsAndSubstancesMatches = concentrations.length === substances.length;
     return nbConcentrationsAndSubstancesMatches
       ? _.zipWith(substances, concentrations, (substance, concentration) => ({ ...substance, concentration }))
       : substances;
+  }
+
+  public static assignHazardsToSubstances(substances: IExtractedSubstance[], hazards: IExtractedDanger[]): IExtractedSubstance[] {
+    if (_.isEmpty(substances) || _.isEmpty(hazards)) return substances;
+
+    _.forEach(hazards, (hazard) => {
+      const closestSubstanceAboveHazard = _.findLast(substances, (substance) => this.isBelow(hazard, substance));
+      if (closestSubstanceAboveHazard) closestSubstanceAboveHazard.hazards = [...(closestSubstanceAboveHazard.hazards || []), hazard];
+    });
+    return substances;
+  }
+
+  private static isBelow(hazard: IExtractedDanger, substance: IExtractedSubstance): boolean {
+    const highestSubstancePosition = this.computeHighestSubstancePosition(substance);
+    const hazardPosition = hazard.metaData.startBox;
+
+    if (hazardPosition.pageNumber !== highestSubstancePosition.pageNumber) return hazardPosition.pageNumber > highestSubstancePosition.pageNumber;
+    return hazardPosition.yPositionProportion >= highestSubstancePosition.yPositionProportion;
+  }
+
+  private static computeHighestSubstancePosition(substance: IExtractedSubstance): IPosition {
+    const positions: IPosition[] = _(substance).map('metaData.startBox').compact().value();
+    return _.minBy(positions, (position) => position.pageNumber * 100 + position.yPositionProportion);
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -658,10 +658,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@padoa/chemical-risk@npm:1.0.0-6b64ca7e6fa4286f8c1ae612208bb2a46f4a8912":
-  version: 1.0.0-6b64ca7e6fa4286f8c1ae612208bb2a46f4a8912
-  resolution: "@padoa/chemical-risk@npm:1.0.0-6b64ca7e6fa4286f8c1ae612208bb2a46f4a8912"
-  checksum: b4a6366e72132678b6b87380eb278f74432d2a1e60029f708bd1146667231d1118cdac6b5efc9fe822ec904834a17cc4839efed2e0941eca720f9ea202b18f0c
+"@padoa/chemical-risk@npm:1.1.0-9b2eb2300541c2c8688ebad211586548b138d9bf":
+  version: 1.1.0-9b2eb2300541c2c8688ebad211586548b138d9bf
+  resolution: "@padoa/chemical-risk@npm:1.1.0-9b2eb2300541c2c8688ebad211586548b138d9bf"
+  checksum: e22fd85bd8846009b30c251c71171621ac8d4989e2d7177ff02193356bfc0f94d2477b14bb63b369223a8eb0a380b948119c2384c97bed4b2f39da30bc829f8d
   languageName: node
   linkType: hard
 
@@ -5625,7 +5625,7 @@ __metadata:
   dependencies:
     "@padoa/async-local-storage": ^2.0.2
     "@padoa/axios": ^5.0.4
-    "@padoa/chemical-risk": 1.0.0-6b64ca7e6fa4286f8c1ae612208bb2a46f4a8912
+    "@padoa/chemical-risk": 1.1.0-9b2eb2300541c2c8688ebad211586548b138d9bf
     "@padoa/csv-tools": ^2.0.4
     "@padoa/database": ^26.2.0
     "@padoa/eslint-plugin": ^2.0.11


### PR DESCRIPTION
### Lien carte Notion

https://www.notion.so/padoa/Moteur-de-FDS-R-gle-H-P-EUH-substances-Rajouter-une-r-gle-sur-la-d-tection-de-phrases-H-P-et-EU-08052bc51bd54857a2a76664cad2c282

ms-fds: https://github.com/padoa/ms-fds/pull/65
pack: https://github.com/padoa/npm-packages/pull/2407
