### PR TITLE
[Fix](RC) Dédupliquer les dangers des substances pour chacune des substances

### DIFF
--- a/src/topics/engine/__tests__/__snapshots__/fds-engine.service.test.ts.snap
+++ b/src/topics/engine/__tests__/__snapshots__/fds-engine.service.test.ts.snap
@@ -416,6 +416,18 @@ exports[`FdsEngine tests > ExtractDataFromFds tests > should extract data from a
           "value": "69011-36-5",
         },
         "ceNumber": undefined,
+        "hazards": [
+          {
+            "code": "H302",
+            "metaData": {
+              "startBox": {
+                "pageNumber": 4,
+                "xPositionProportion": 0.09047619047619047,
+                "yPositionProportion": 0.3643097643097643,
+              },
+            },
+          },
+        ],
       },
       {
         "casNumber": {
@@ -502,6 +514,16 @@ exports[`FdsEngine tests > ExtractDataFromFds tests > should extract data from a
                 "pageNumber": 4,
                 "xPositionProportion": 0.5085714285714286,
                 "yPositionProportion": 0.4653198653198653,
+              },
+            },
+          },
+          {
+            "code": "H400",
+            "metaData": {
+              "startBox": {
+                "pageNumber": 4,
+                "xPositionProportion": 0.7542857142857143,
+                "yPositionProportion": 0.48013468013468014,
               },
             },
           },

--- a/src/topics/engine/rules/extraction-rules/__tests__/substance/substance-hazards-rules.service.test.ts
+++ b/src/topics/engine/rules/extraction-rules/__tests__/substance/substance-hazards-rules.service.test.ts
@@ -49,6 +49,11 @@ describe('SubstanceHazardsRulesService tests', () => {
         lines: [[aText().withContent('H300 and some other text H400').properties], []],
         expected: [aDanger().withCode('H300').properties, aDanger().withCode('H400').properties],
       },
+      {
+        message: 'should return multiple identical hazards if a hazard appears on multiple lines',
+        lines: [[aTextWithHDanger().properties, aTextWithHDanger().properties], []],
+        expected: [aHDanger().properties, aHDanger().properties],
+      },
     ])('$message', ({ lines, expected }) => {
       expect(SubstanceHazardsRulesService.getHazardsInColumn(lines)).toEqual(expected);
     });

--- a/src/topics/engine/rules/extraction-rules/__tests__/substances-rules.service.test.ts
+++ b/src/topics/engine/rules/extraction-rules/__tests__/substances-rules.service.test.ts
@@ -92,7 +92,7 @@ describe('SubstancesRulesService tests', () => {
         expected: [aSubstance().withHazards([aHDanger().properties, aDanger().withCode('h300').properties]).properties],
       },
       {
-        message: 'should return substance with uniq hazards',
+        message: 'should return substance with unique hazards',
         substances: [aSubstanceWithoutHazards().properties],
         hazards: [aHDanger().properties, aHDanger().properties],
         expected: [aSubstance().withHazards([aHDanger().properties]).properties],

--- a/src/topics/engine/rules/extraction-rules/__tests__/substances-rules.service.test.ts
+++ b/src/topics/engine/rules/extraction-rules/__tests__/substances-rules.service.test.ts
@@ -92,6 +92,12 @@ describe('SubstancesRulesService tests', () => {
         expected: [aSubstance().withHazards([aHDanger().properties, aDanger().withCode('h300').properties]).properties],
       },
       {
+        message: 'should return substance with uniq hazards',
+        substances: [aSubstanceWithoutHazards().properties],
+        hazards: [aHDanger().properties, aHDanger().properties],
+        expected: [aSubstance().withHazards([aHDanger().properties]).properties],
+      },
+      {
         message: 'should return substance with hazards affected to the correct substances when hazards are on multiple lines on the same page',
         substances: [aSubstanceWithoutHazards().properties, aSubstanceStarting1LineBelow().properties],
         hazards: [

--- a/src/topics/engine/rules/extraction-rules/substance/substance-hazards-rules.service.ts
+++ b/src/topics/engine/rules/extraction-rules/substance/substance-hazards-rules.service.ts
@@ -22,7 +22,6 @@ export class SubstanceHazardsRulesService {
         }));
       })
       .flatten()
-      .uniqBy('code')
       .value();
   }
 }

--- a/src/topics/engine/rules/extraction-rules/substances-rules.service.ts
+++ b/src/topics/engine/rules/extraction-rules/substances-rules.service.ts
@@ -38,7 +38,8 @@ export class SubstancesRulesService {
 
     _.forEach(hazards, (hazard) => {
       const closestSubstanceAboveHazard = _.findLast(substances, (substance) => this.isBelow(hazard, substance));
-      if (closestSubstanceAboveHazard) closestSubstanceAboveHazard.hazards = [...(closestSubstanceAboveHazard.hazards || []), hazard];
+      if (closestSubstanceAboveHazard)
+        closestSubstanceAboveHazard.hazards = _.uniqBy([...(closestSubstanceAboveHazard.hazards || []), hazard], 'code');
     });
     return substances;
   }


### PR DESCRIPTION
### Description

Aujourd'hui les dangers des substances sont dédupliqués pour toutes les substances et pas par substance. Cette pr corrige ce comportement.
